### PR TITLE
fix: capture complete body content

### DIFF
--- a/src/ring/rack.clj
+++ b/src/ring/rack.clj
@@ -25,8 +25,9 @@
 
       def responsify(output)
         begin
-          return output[0].to_java if output.respond_to?(:size) && output.size > 1
-          output.each{|s| s.to_java}
+          retval = []
+          output.each {|s| retval.push(s)}
+          retval
         ensure
           output.close if output.respond_to?(:close)
          end


### PR DESCRIPTION
The Rack spec defines a body that responds to _each_ and takes a
block. The block should receive a string, which means that we now endup
with a array of strings that can be converted to an ISeq for Ring.
